### PR TITLE
Fix osx build

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -9,8 +9,10 @@
         "netlink/socket_group.cc",
         "netlink/util.cc"
       ],
-      "cflags!": [ "-fexceptions" ],
-      "cflags_cc!": [ "-fexceptions" ],
+      "cflags": [ "-fexceptions" ],
+      "cflags_cc": [ "-fexceptions" ],
+      "cflags!": [ "-fno-exceptions" ],
+      "cflags_cc!": [ "-fno-exceptions" ],
       "conditions": [
         ['OS=="win"', {
           "libraries": [ "ws2_32.lib" ]

--- a/binding.gyp
+++ b/binding.gyp
@@ -9,14 +9,17 @@
         "netlink/socket_group.cc",
         "netlink/util.cc"
       ],
-      "cflags": [ "-fexceptions" ],
-      "cflags_cc": [ "-fexceptions" ],
-      "cflags!": [ "-fno-exceptions" ],
-      "cflags_cc!": [ "-fno-exceptions" ],
+      "cflags!": [ "-fexceptions" ],
+      "cflags_cc!": [ "-fexceptions" ],
       "conditions": [
         ['OS=="win"', {
           "libraries": [ "ws2_32.lib" ]
-        }]
+        },
+         'OS=="mac"', {
+          "xcode_settings": {
+              "GCC_ENABLE_CPP_EXCEPTIONS": "YES"
+          }
+         }]
       ]
     }
   ]

--- a/netlink/core.h
+++ b/netlink/core.h
@@ -66,6 +66,7 @@
     #include <netdb.h>
     #include <sys/ioctl.h>
     #include <errno.h>
+    #include <unistd.h>
 
 #endif
 


### PR DESCRIPTION
Fix to binding.gyp for appropriate flags when building on osx. Also addition of unistd.h header for osx socket compatibility.