### PR TITLE
Fix node gyp build node 10

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -24,6 +24,9 @@
             }
           }
         ]
+      ],
+      "include_dirs" : [
+          "<!(node -e \"require('nan')\")"
       ]
     }
   ]

--- a/netlinkwrapper.cc
+++ b/netlinkwrapper.cc
@@ -1,3 +1,4 @@
+#include <nan.h>
 #include "netlinkwrapper.h"
 #include "netlink/exception.h"
 
@@ -55,7 +56,7 @@ void NetLinkWrapper::New(const FunctionCallbackInfo<Value>& args)
         const int argc = 1;
         Local<Value> argv[argc] = { args[0] };
         Local<Function> cons = Local<Function>::New(isolate, constructor);
-        args.GetReturnValue().Set(cons->NewInstance(argc, argv));
+        args.GetReturnValue().Set(Nan::NewInstance(cons, argc, argv).ToLocalChecked());
     }
 }
 

--- a/package.json
+++ b/package.json
@@ -4,14 +4,23 @@
   "description": "This is a simple node-gyp module wrapper for the C++ library netLink v1.0.0_pre6",
   "author": "JacobFischer <jacob.t.fischer@gmail.com>",
   "main": "main.js",
-  "keywords": [ "net", "sync", "synchronous", "tcp", "socket", "network", "addon" ],
-  "repository" : {
-    "type" : "git",
-    "url" : "https://github.com/JacobFischer/netlinkwrapper.git"
+  "keywords": [
+    "net",
+    "sync",
+    "synchronous",
+    "tcp",
+    "socket",
+    "network",
+    "addon"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/JacobFischer/netlinkwrapper.git"
   },
   "gypfile": true,
   "dependencies": {
-    "bindings": "~1.2.1"
+    "bindings": "~1.2.1",
+    "nan": "^2.11.0"
   },
   "license": "MIT",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,12 @@
     "bindings": "~1.2.1",
     "nan": "^2.11.0"
   },
+  "devDependencies": {
+    "mocha": "^5.2.0"
+  },
+  "scripts": {
+    "test": "mocha"
+  },
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/JacobFischer/netlinkwrapper/issues"

--- a/test/apps/client.js
+++ b/test/apps/client.js
@@ -1,0 +1,21 @@
+'use strict';
+
+var netlinkwrapper = require('../..');
+var netlink = new netlinkwrapper();
+
+netlink.connect(3000, 'localhost');
+netlink.blocking(false);
+
+netlink.write('Anybody out there?');
+
+var keepReading = true;
+while (keepReading) {
+  var str = netlink.read(1024);
+  if (str) {
+    console.log('RECEIVED:', str);
+    if (str.indexOf('bye') >= 0) {
+      keepReading = false;
+    }
+  }
+}
+

--- a/test/apps/server.js
+++ b/test/apps/server.js
@@ -1,0 +1,26 @@
+'use strict';
+
+var net = require('net');
+
+var port = 3000;
+
+var server = net.createServer(function(socket) {
+  socket.on('data', function(data) {
+    console.log('RECEIVED:', data.toString());
+    socket.write(data);
+    socket.write('bye');
+    socket.end();
+    setTimeout(function() {
+      process.exit(0);
+    }, 50);
+  });
+});
+
+server.on('error', (err) => {
+  throw err;
+});
+
+server.listen(port, () => {
+  console.log('server is listening on port ' + port);
+});
+

--- a/test/test.js
+++ b/test/test.js
@@ -1,0 +1,103 @@
+'use strict';
+
+var spawn = require('child_process').spawn;
+
+describe('TCP communication', function() {
+
+  var serverIsReady = false;
+  var waitsServerStart = 0;
+  var serverHasResponded = false;
+  var serverHasSaidBye = false;
+  var waitsClient = 0;
+  var waitDelay = 20;
+  var maxWaits = 10;
+
+  var serverProcess;
+  var clientProcess;
+
+  beforeEach(function(done) {
+    startServer();
+    waitUntilServerIsReady(done);
+  });
+
+  afterEach(function() {
+    if (serverProcess) {
+      serverProcess.kill();
+    }
+    if (clientProcess) {
+      clientProcess.kill();
+    }
+  });
+
+  it('should work', function(done) {
+    startClient();
+    waitUntilCommunicationHasHappened(done)
+  });
+
+  function startServer() {
+    serverProcess = spawn('node', ['test/apps/server'], {
+      stdio: [0, 'pipe', process.stderr]
+    });
+
+    serverProcess.stdout.on('data', (data) => {
+      var str = data.toString();
+      console.log('[server stdout]:', str);
+      if (str.indexOf('server is listening on port 3000') >= 0) {
+        serverIsReady = true;
+      }
+    });
+  }
+
+  function waitUntilServerIsReady(callback) {
+    if (serverIsReady) {
+      process.nextTick(function() {
+        callback();
+      });
+    } else {
+      waitsServerStart++;
+      if (waitsServerStart < maxWaits) {
+        setTimeout(
+          waitUntilServerIsReady.bind(null, callback),
+          waitDelay
+        );
+      } else {
+        callback(new Error('Server did not come up.'));
+      }
+    }
+  }
+
+  function startClient() {
+    clientProcess = spawn('node', ['test/apps/client'], {
+      stdio: [0, 'pipe', process.stderr]
+    });
+    clientProcess.stdout.on('data', (data) => {
+      var str = data.toString();
+      console.log('[client stdout]:', str);
+      if (str.indexOf('RECEIVED: Anybody out there?') >= 0) {
+        serverHasResponded = true;
+      }
+      if (str.indexOf('RECEIVED: bye') >= 0) {
+        serverHasSaidBye = true;
+      }
+    });
+  }
+
+  function waitUntilCommunicationHasHappened(callback) {
+    if (serverHasResponded && serverHasSaidBye) {
+      process.nextTick(function() {
+        callback();
+      });
+    } else {
+      waitsClient++;
+      if (waitsClient < maxWaits) {
+        setTimeout(
+          waitUntilCommunicationHasHappened.bind(null, callback),
+          waitDelay
+        );
+      } else {
+        callback(new Error('TCP communication did not happen.'));
+      }
+    }
+  }
+});
+


### PR DESCRIPTION
The build breaks on Node.js 10 with

```
../netlinkwrapper.cc:58:41: error: no matching member function for call to 'NewInstance'
        args.GetReturnValue().Set(cons->NewInstance(argc, argv));
                                  ~~~~~~^~~~~~~~~~~
```

This change fixes this, so the module can also be used with the latest Node.js version.

(Note that the build in Node.js 8 also emitted a corresponding deprecation warning: 

```
../netlinkwrapper.cc:58:41: warning: 'NewInstance' is deprecated [-Wdeprecated-declarations]
        args.GetReturnValue().Set(cons->NewInstance(argc, argv));
                                        ^
/Users/bastian/.node-gyp/8.11.3/include/node/v8.h:3846:3: note: 'NewInstance' has been explicitly marked deprecated here
  V8_DEPRECATED("Use maybe version",
 ```

I also added a test case for the TCP client functionality and tested the library for all the Node versions from 4 to 10 (latest patch version for each major version) successfully via `rm -rf node_modules && npm install && rm -rf package-lock.json && node-gyp rebuild && npm test`, so I'm quite confident that the change in the production code doesn't break the library for older versions.