### PR TITLE
 Fix for building against musl libc

### DIFF
--- a/netlink/core.h
+++ b/netlink/core.h
@@ -58,10 +58,10 @@
     #define OS_LINUX
 
     #include <arpa/inet.h>
-    #include <sys/fcntl.h>
+    #include <fcntl.h>
     #include <sys/types.h>
     #include <sys/socket.h>
-    #include <sys/unistd.h>
+    #include <unistd.h>
     #include <sys/time.h>
     #include <netdb.h>
     #include <sys/ioctl.h>

--- a/test/test.js
+++ b/test/test.js
@@ -76,7 +76,7 @@ describe('TCP communication', function() {
       if (str.indexOf('RECEIVED: Anybody out there?') >= 0) {
         serverHasResponded = true;
       }
-      if (str.indexOf('RECEIVED: bye') >= 0) {
+      if (str.indexOf('bye') >= 0) {
         serverHasSaidBye = true;
       }
     });


### PR DESCRIPTION
Fix for building against musl libc

This fix enables the package to be built against
[musl libc](https://www.musl-libc.org/) instead of glibc. Musl libc is
used in the Linux Alpine distro and since the
[official Node.js Docker repo](https://hub.docker.com/_/node/)
advertises its Alpine based images as "highly recommended
when final image size being as small as possible is desired", it turns
out that quite a few people run Node.js on Alpine via these images.

This change should not have any impact on systems that use the more
widespread glibc, as the updated imports should be available in all
libc variants.