### PR TITLE
Update NetlinkWrapper do accommodate changes in v8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
-language: nodejs
+language: node_js
+node_js:
+  - "12"
 
 script:
   # this builds the module, if it fails the build did not pass

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: node_js
 node_js:
+  - "6"
+  - "8"
+  - "10"
   - "12"
 
 script:

--- a/netlinksocket.cc
+++ b/netlinksocket.cc
@@ -3,7 +3,7 @@
 
 using namespace v8;
 
-void InitAll(Handle<Object> exports)
+void InitAll(Local<Object> exports)
 {
     NetLinkWrapper::Init(exports);
 }

--- a/netlinkwrapper.cc
+++ b/netlinkwrapper.cc
@@ -18,7 +18,7 @@ NetLinkWrapper::~NetLinkWrapper()
     }
 }
 
-void NetLinkWrapper::Init(Handle<Object> exports)
+void NetLinkWrapper::Init(Local<Object> exports)
 {
     Isolate* isolate = Isolate::GetCurrent();
 

--- a/netlinkwrapper.cc
+++ b/netlinkwrapper.cc
@@ -21,6 +21,7 @@ NetLinkWrapper::~NetLinkWrapper()
 void NetLinkWrapper::Init(Local<Object> exports)
 {
     Isolate* isolate = Isolate::GetCurrent();
+    Local<Context> context = isolate->GetCurrentContext();
 
     // Prepare constructor template
     Local<FunctionTemplate> tpl = FunctionTemplate::New(isolate, New);
@@ -34,8 +35,8 @@ void NetLinkWrapper::Init(Local<Object> exports)
     NODE_SET_PROTOTYPE_METHOD(tpl, "write", Write);
     NODE_SET_PROTOTYPE_METHOD(tpl, "disconnect", Disconnect);
 
-    constructor.Reset(isolate, tpl->GetFunction());
-    exports->Set(String::NewFromUtf8(isolate, "NetLinkWrapper"), tpl->GetFunction());
+    constructor.Reset(isolate, tpl->GetFunction(context).ToLocalChecked());
+    exports->Set(String::NewFromUtf8(isolate, "NetLinkWrapper"), tpl->GetFunction(context).ToLocalChecked());
 }
 
 void NetLinkWrapper::New(const FunctionCallbackInfo<Value>& args)
@@ -78,12 +79,12 @@ void NetLinkWrapper::Connect(const FunctionCallbackInfo<Value>& args)
         isolate->ThrowException(Exception::TypeError(String::NewFromUtf8(isolate, "'connect' second arg should be number for port on server")));
         return;
     }
-    int port = (int)args[0]->NumberValue();
+    int port = (int)args[0]->NumberValue(isolate->GetCurrentContext()).ToChecked();
 
     std::string server = "127.0.0.1";
     if(args[1]->IsString())
     {
-        v8::String::Utf8Value param1(args[1]->ToString());
+        v8::String::Utf8Value param1(isolate, args[1]->ToString(isolate));
         server = std::string(*param1);
     }
 
@@ -129,7 +130,7 @@ void NetLinkWrapper::Blocking(const FunctionCallbackInfo<Value>& args)
 
         try
         {
-            obj->socket->blocking(args[0]->BooleanValue());
+            obj->socket->blocking(args[0]->BooleanValue(isolate));
         }
         catch(NL::Exception& e)
         {
@@ -156,13 +157,13 @@ void NetLinkWrapper::Read(const FunctionCallbackInfo<Value>& args)
         isolate->ThrowException(Exception::TypeError(String::NewFromUtf8(isolate, "'read' first argument must be a number representing how many bytes to try to read")));
         return;
     }
-    size_t bufferSize = (int)args[0]->NumberValue();
+    size_t bufferSize = (int)args[0]->NumberValue(isolate->GetCurrentContext()).ToChecked();
     char* buffer = new char[bufferSize];
 
     if(args.Length() == 2 && args[0]->IsBoolean()) {
         try
         {
-            obj->socket->blocking(args[1]->BooleanValue());
+            obj->socket->blocking(args[1]->BooleanValue(isolate->GetCurrentContext()).ToChecked());
         }
         catch(NL::Exception& e)
         {
@@ -204,7 +205,7 @@ void NetLinkWrapper::Write(const FunctionCallbackInfo<Value>& args)
         isolate->ThrowException(Exception::TypeError(String::NewFromUtf8(isolate, "'send' first argument must be a string to send")));
         return;
     }
-    v8::String::Utf8Value param1(args[0]->ToString());
+    v8::String::Utf8Value param1(isolate,args[0]->ToString(isolate));
     std::string writing(*param1);
 
     try

--- a/netlinkwrapper.cc
+++ b/netlinkwrapper.cc
@@ -21,7 +21,6 @@ NetLinkWrapper::~NetLinkWrapper()
 void NetLinkWrapper::Init(Local<Object> exports)
 {
     Isolate* isolate = Isolate::GetCurrent();
-    Local<Context> context = isolate->GetCurrentContext();
 
     // Prepare constructor template
     Local<FunctionTemplate> tpl = FunctionTemplate::New(isolate, New);
@@ -35,8 +34,8 @@ void NetLinkWrapper::Init(Local<Object> exports)
     NODE_SET_PROTOTYPE_METHOD(tpl, "write", Write);
     NODE_SET_PROTOTYPE_METHOD(tpl, "disconnect", Disconnect);
 
-    constructor.Reset(isolate, tpl->GetFunction(context).ToLocalChecked());
-    exports->Set(String::NewFromUtf8(isolate, "NetLinkWrapper"), tpl->GetFunction(context).ToLocalChecked());
+    constructor.Reset(isolate, Nan::GetFunction(tpl).ToLocalChecked());
+    exports->Set(String::NewFromUtf8(isolate, "NetLinkWrapper"), Nan::GetFunction(tpl).ToLocalChecked());
 }
 
 void NetLinkWrapper::New(const FunctionCallbackInfo<Value>& args)

--- a/netlinkwrapper.cc
+++ b/netlinkwrapper.cc
@@ -78,7 +78,7 @@ void NetLinkWrapper::Connect(const FunctionCallbackInfo<Value>& args)
         isolate->ThrowException(Exception::TypeError(String::NewFromUtf8(isolate, "'connect' second arg should be number for port on server")));
         return;
     }
-    int port = (int)args[0]->NumberValue(isolate->GetCurrentContext()).ToChecked();
+    int port = (int)args[0]->NumberValue(isolate->GetCurrentContext()).FromJust();
 
     std::string server = "127.0.0.1";
     if(args[1]->IsString())
@@ -129,7 +129,7 @@ void NetLinkWrapper::Blocking(const FunctionCallbackInfo<Value>& args)
 
         try
         {
-            obj->socket->blocking(args[0]->BooleanValue(isolate->GetCurrentContext()).ToChecked());
+            obj->socket->blocking(args[0]->BooleanValue(isolate->GetCurrentContext()).FromJust());
         }
         catch(NL::Exception& e)
         {
@@ -156,13 +156,13 @@ void NetLinkWrapper::Read(const FunctionCallbackInfo<Value>& args)
         isolate->ThrowException(Exception::TypeError(String::NewFromUtf8(isolate, "'read' first argument must be a number representing how many bytes to try to read")));
         return;
     }
-    size_t bufferSize = (int)args[0]->NumberValue(isolate->GetCurrentContext()).ToChecked();
+    size_t bufferSize = (int)args[0]->NumberValue(isolate->GetCurrentContext()).FromJust();
     char* buffer = new char[bufferSize];
 
     if(args.Length() == 2 && args[0]->IsBoolean()) {
         try
         {
-            obj->socket->blocking(args[1]->BooleanValue(isolate->GetCurrentContext()).ToChecked());
+            obj->socket->blocking(args[1]->BooleanValue(isolate->GetCurrentContext()).FromJust());
         }
         catch(NL::Exception& e)
         {

--- a/netlinkwrapper.cc
+++ b/netlinkwrapper.cc
@@ -129,7 +129,7 @@ void NetLinkWrapper::Blocking(const FunctionCallbackInfo<Value>& args)
 
         try
         {
-            obj->socket->blocking(args[0]->BooleanValue(isolate));
+            obj->socket->blocking(args[0]->BooleanValue(isolate->GetCurrentContext()).ToChecked());
         }
         catch(NL::Exception& e)
         {

--- a/netlinkwrapper.cc
+++ b/netlinkwrapper.cc
@@ -83,7 +83,7 @@ void NetLinkWrapper::Connect(const FunctionCallbackInfo<Value>& args)
     std::string server = "127.0.0.1";
     if(args[1]->IsString())
     {
-        v8::String::Utf8Value param1(isolate, args[1]->ToString(isolate));
+        Nan::Utf8String param1(args[1]);
         server = std::string(*param1);
     }
 
@@ -204,7 +204,7 @@ void NetLinkWrapper::Write(const FunctionCallbackInfo<Value>& args)
         isolate->ThrowException(Exception::TypeError(String::NewFromUtf8(isolate, "'send' first argument must be a string to send")));
         return;
     }
-    v8::String::Utf8Value param1(isolate,args[0]->ToString(isolate));
+    Nan::Utf8String param1(args[0]);
     std::string writing(*param1);
 
     try

--- a/netlinkwrapper.h
+++ b/netlinkwrapper.h
@@ -8,7 +8,7 @@
 class NetLinkWrapper : public node::ObjectWrap
 {
     public:
-        static void Init(v8::Handle<v8::Object> exports);
+        static void Init(v8::Local<v8::Object> exports);
 
     private:
         NL::Socket* socket;

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,9 +17,12 @@
       "dev": true
     },
     "bindings": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.0.tgz",
-      "integrity": "sha512-DpLh5EzMR2kzvX1KIlVC0VkC3iZtHKTgdtZ0a3pglBZdaQFjt5S9g9xd1lE+YvXyfd6mtCeRnrUfOLYiTMlNSw=="
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
     },
     "bluebird": {
       "version": "3.5.1",
@@ -90,6 +93,11 @@
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
+    },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -274,9 +282,9 @@
       "dev": true
     },
     "nan": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.0.tgz",
-      "integrity": "sha512-F4miItu2rGnV2ySkXOQoA8FKz/SR2Q2sWP0sbTxNxz/tuokeC8WxOhPMcwi0qIyGtVn/rrSeLbvVkznqCdwYnw=="
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
     },
     "once": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
   "gypfile": true,
   "types": "index.d.ts",
   "dependencies": {
-    "bindings": "1.3.0",
-    "nan": "2.11.0"
+    "bindings": "1.5.0",
+    "nan": "2.14.0"
   },
   "devDependencies": {
     "jaguarjs-jsdoc": "github:JacobFischer/jaguarjs-jsdoc",


### PR DESCRIPTION
This PR attempts to fix issue https://github.com/JacobFischer/netlinkwrapper/issues/8

v8 had breaking changes where it now favors the usage of `Local` over `Handle` and most functions require the passing of either an `Isolate` or `Context`. In addition to that the return type of some functions has changed to `Maybe<T>` which requires to call `ToChecked()` on the returned valued.

I added a matrix build to Travis .travis.yml` in order to ensure compatibility with Node 6, 8, 10 and 12